### PR TITLE
Fix unstable issues when transfer message larger than 72MBit.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,8 @@ set(CMAKE_CXX_STANDARD 17)
 # For build share library
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(CMAKE_BUILD_TYPE RelWithDebInfo)
-
-# set(CMAKE_BUILD_TYPE Debug)
+# set(CMAKE_BUILD_TYPE RelWithDebInfo)
+set(CMAKE_BUILD_TYPE Debug)
 # set(CMAKE_BUILD_TYPE Release)
 
 # set spdlog macro

--- a/include/transport/shmTransport.h
+++ b/include/transport/shmTransport.h
@@ -180,11 +180,11 @@ namespace dawn
     /// @param indexBlock 
     /// @return PROCESS_SUCCESS: lock successfully and read buffer. 
     ///         PROCESS_FAIL: buffer is empty or buffer isn't initialize and will not lock.
-    bool watchEndIndex(ringBufferIndexBlockType &indexBlock);
+    bool watchRingBuffer(ringBufferIndexBlockType &indexBlock);
 
-    /// @brief Unlock end index.
+    /// @brief Unlock ring buffer.
     /// @return 
-    bool stopWatchEndIndex();
+    bool stopWatchRingBuffer();
 
     /// @brief Pass indexBlock to compare the the block pointing by start index. If they are same, start index will move.
     /// @param indexBlock 
@@ -206,6 +206,7 @@ namespace dawn
     std::shared_ptr<BI::shared_memory_object>       ringBufferShm_ptr_;
     std::shared_ptr<BI::mapped_region>              ringBufferShmRegion_ptr_;
     BI::scoped_lock<BI::interprocess_mutex>         endIndex_lock_;
+    BI::scoped_lock<BI::interprocess_mutex>         startIndex_lock_;
 
     ringBufferType                                  *ringBuffer_raw_ptr_;
     std::string                                     shmIdentity_;

--- a/test/test_impl.cpp
+++ b/test/test_impl.cpp
@@ -233,29 +233,39 @@ TEST(test_dawn, test_shmTp_read_loop)
   }
 }
 
+#include <signal.h>
+
 TEST(test_dawn, test_shmTp_read_loop_block)
 {
-
   using namespace dawn;
   using TP = abstractTransport;
   shmTransport shm_tp("hello_world_dawn");
-  for (;;)
+  try
   {
-    char* data = new char[9 * 1024 * 1024];
-    uint32_t len = 0;
-    if (shm_tp.read(data, len, TP::BLOCK_TYPE::BLOCK) == PROCESS_FAIL)
+    for (;;)
     {
-      std::cout << "failed" << std::endl;
+      char* data = new char[9 * 1024 * 1024];
+      uint32_t len = 0;
+      if (shm_tp.read(data, len, TP::BLOCK_TYPE::BLOCK) == PROCESS_FAIL)
+      {
+        std::cout << "failed" << std::endl;
+      }
+      else
+      {
+        LOG_INFO("end");
+        LOG_INFO("receive data {}", data);
+        std::cout << "receive data " << data << std::endl;
+        std::cout << "receive data len " << len << std::endl << std::endl;
+      }
+      delete data;
     }
-    else
-    {
-      LOG_INFO("end");
-      LOG_INFO("receive data {}", data);
-      std::cout << "receive data " << data << std::endl;
-      std::cout << "receive data len " << len << std::endl << std::endl;
-    }
-    delete data;
   }
+  catch (const std::exception& e)
+  {
+    std::cerr << e.what() << '\n';
+    raise(SIGABRT);
+  }
+
 }
 
 TEST(test_dawn, test_shmTp_read_one_slot)
@@ -308,7 +318,7 @@ TEST(test_dawn, test_shmTp_write_large_data)
   {
     std::string data = "helloWorld large data";
 
-    data.resize(1024 * 1024 * 9);
+    data.resize(1024 * 1024);
 
     std::cout << "publish data " << data << std::endl;
     if (shm_tp.write(data.c_str(), data.size()) == PROCESS_FAIL)
@@ -324,17 +334,17 @@ TEST(test_dawn, test_shmTp_write_large_data_loop)
   using namespace dawn;
   shmTransport shm_tp("hello_world_dawn");
 
-  for (int i = 0; i < 0xfff; i++)
+  for (int i = 0; i < 0xffff; i++)
   {
     std::string data = "helloWorld";
     data += std::to_string(i);
     std::cout << "publish data " << data << std::endl;
-    data.resize(1024 * 1024 * 9);
+    data.resize(1024 * 1024);
     if (shm_tp.write(data.c_str(), data.size()) == PROCESS_FAIL)
     {
       std::cout << "failed" << std::endl;
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    // std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }
 }
 


### PR DESCRIPTION
Fix unstable issues when transfer message larger than 72MBit. 
Issue include:
1. Recycle message staying at start index when other process is reading this message.
2. Relesae the end index mutex even if the end index mutex are not be locked in `shmTransportImpl::read` function.